### PR TITLE
Update OutlinePass.js

### DIFF
--- a/OutlinePass.js
+++ b/OutlinePass.js
@@ -401,7 +401,7 @@ THREE.RenderPass.prototype = Object.assign(Object.create(THREE.Pass.prototype), 
 
 		if (this.clearColor) {
 
-			oldClearColor = renderer.getClearColor().getHex();
+			oldClearColor = renderer.getClearColor(new THREE.Color()).getHex();
 			oldClearAlpha = renderer.getClearAlpha();
 
 			renderer.setClearColor(this.clearColor, this.clearAlpha);
@@ -761,7 +761,7 @@ THREE.OutlinePass.prototype = Object.assign(Object.create(THREE.Pass.prototype),
 
 		if (this.selectedObjects.length > 0) {
 
-			this.oldClearColor.copy(renderer.getClearColor());
+			this.oldClearColor.copy(renderer.getClearColor(new THREE.Color()));
 			this.oldClearAlpha = renderer.getClearAlpha();
 			var oldAutoClear = renderer.autoClear;
 


### PR DESCRIPTION
Add an argument to getClearColor to prevent warnings in v124+.

![image](https://user-images.githubusercontent.com/253069/112729209-44a2aa00-8ee8-11eb-8179-6fe1559b8642.png)

https://github.com/mrdoob/three.js/wiki/Migration-Guide#r123--r124